### PR TITLE
riot: add unique_id() support based on cpuid

### DIFF
--- a/ports/riot/modmachine.c
+++ b/ports/riot/modmachine.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 
 #include "periph/pm.h"
+#include "periph/cpuid.h"
 
 #include "py/obj.h"
 #include "py/runtime.h"
@@ -50,10 +51,22 @@ STATIC mp_obj_t machine_reset_cause(void) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(machine_reset_cause_obj, machine_reset_cause);
 
+#ifdef MODULE_PERIPH_CPUID
+STATIC mp_obj_t machine_unique_id(void) {
+    uint8_t chipid[CPUID_LEN];
+    cpuid_get(chipid);
+    return mp_obj_new_bytes(chipid, CPUID_LEN);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(machine_unique_id_obj, machine_unique_id);
+#endif
+
 STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_umachine) },
     { MP_ROM_QSTR(MP_QSTR_reset), MP_ROM_PTR(&machine_reset_obj) },
     { MP_ROM_QSTR(MP_QSTR_reset_cause), MP_ROM_PTR(&machine_reset_cause_obj) },
+#ifdef MODULE_PERIPH_CPUID
+    { MP_ROM_QSTR(MP_QSTR_unique_id), MP_ROM_PTR(&machine_unique_id_obj) },
+#endif
 
     { MP_ROM_QSTR(MP_QSTR_Pin), MP_ROM_PTR(&machine_pin_type) },
 


### PR DESCRIPTION
Played around a bit and got `machine.unique_id()` working based on `periph/cpuid.h`. Implementation is `ifdef`fed in case the target doesn't support cpuid. End user application can add a requirement to cpuid or the package could add a `FEATURES_OPTIONAL += periph_cpuid`

Depending on the pending discussion I can close this one and open one either at kaspar030/micropython or directly upstream when it is up to date.